### PR TITLE
Fix `pytesseract.pytesseract.TesseractNotFoundError`

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,0 +1,1 @@
+tesseract-ocr

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -39,7 +39,6 @@ for y in urls:
     urls_list.append(y)
 
     if x != "-":
-      (pathlib.Path(x).suffix)
       if pathlib.Path(x).suffix in img_formats:
         response = requests.get(x)
         img = Image.open(io.BytesIO(response.content))


### PR DESCRIPTION
This PR installs a prerequisite [Google Tesseract OCR](https://github.com/tesseract-ocr/tesseract) linux binary for `pytesseract` to prevent the `pytesseract.pytesseract.TesseractNotFoundError`.